### PR TITLE
Collect failed job counts for each failed queue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 resque_exporter
 ==
 
-An exporter of [Prometheus](https://prometheus.io) for [resque](https://github.com/resque/resque)'s status.
+An exporter of [Prometheus](https://prometheus.io) for [Resque](https://github.com/resque/resque)'s status.
 
 Usage
 --
@@ -30,6 +30,7 @@ This exporter exports following items.
 - Number of processed jobs
 - Number of failed jobs
 - Number of jobs in the `failed` queue
+- Number of jobs in each of the `*_failed` queues
 - Number of total workers
 - Number of active workers
 - Number of idle workers
@@ -56,6 +57,10 @@ Sample Output
 # TYPE resque_jobs_in_queue gauge
 resque_jobs_in_queue{queue_name="image_converting"} 0
 resque_jobs_in_queue{queue_name="log_compression"} 0
+# HELP resque_jobs_in_failed_queue Number of jobs in failed queue
+# TYPE resque_jobs_in_failed_queue gauge
+resque_jobs_in_failed_queue{queue_name="image_converting_failed"} 0
+resque_jobs_in_failed_queue{queue_name="log_compression_failed"} 0
 # HELP resque_failed Number of failed jobs
 # TYPE resque_failed gauge
 resque_failed 123
@@ -79,10 +84,12 @@ resque_total_workers 10
 Mechanism
 --
 
-This exporter accesses to redis to aggregate status.
+This exporter connects directly to Redis to collect aggregated stats.
 
-1. Collect name of queues via `<namespace>:queues` entry (by using [SMEMBERS](http://redis.io/commands/smembers))
+1. Collect names of queues via `<namespace>:queues` entry (by using [SMEMBERS](http://redis.io/commands/smembers))
 1. Get number of remained jobs for each queue via `<namespace>:queue:<queue_name>` entry (by using [LLEN](http://redis.io/commands/llen))
+1. Collect names of failed queues via `<namespace>:failed_queues` entry (by using [SMEMBERS](http://redis.io/commands/smembers))
+1. Get number of failed jobs for each failed queue via `<namespace>:<failed_queue_name>` entry (by using [LLEN](http://redis.io/commands/llen))
 1. Get number of processed jobs via `<namespace>:stat:processed`
 1. Get number of failed jobs via `<namespace>:stat:failed`
 1. Collect name of workers via `<namespace>:workers` entry (by using [SMEMBERS](http://redis.io/commands/smembers))
@@ -96,7 +103,7 @@ Any paths that except for `/metrics` returns response for health check. It retur
 Note
 --
 
-This exporter also supports resque compatible job-queue engine (e.g. [jesque](https://github.com/gresrun/jesque)).
+This exporter also supports Resque compatible job-queue engine (e.g. [jesque](https://github.com/gresrun/jesque)).
 
 [For developers] How to build to release
 --
@@ -128,4 +135,3 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
-

--- a/exporter.go
+++ b/exporter.go
@@ -13,17 +13,18 @@ import (
 const namespace = "resque"
 
 type exporter struct {
-	config         *Config
-	mut            sync.Mutex
-	scrapeFailures prometheus.Counter
-	processed      prometheus.Gauge
-	failedQueue    prometheus.Gauge
-	failedTotal    prometheus.Gauge
-	queueStatus    *prometheus.GaugeVec
-	totalWorkers   prometheus.Gauge
-	activeWorkers  prometheus.Gauge
-	idleWorkers    prometheus.Gauge
-	timer          *time.Timer
+	config            *Config
+	mut               sync.Mutex
+	scrapeFailures    prometheus.Counter
+	processed         prometheus.Gauge
+	failedQueue       prometheus.Gauge
+	failedTotal       prometheus.Gauge
+	queueStatus       *prometheus.GaugeVec
+	failedQueueStatus *prometheus.GaugeVec
+	totalWorkers      prometheus.Gauge
+	activeWorkers     prometheus.Gauge
+	idleWorkers       prometheus.Gauge
+	timer             *time.Timer
 }
 
 func newExporter(config *Config) (*exporter, error) {
@@ -34,6 +35,14 @@ func newExporter(config *Config) (*exporter, error) {
 				Namespace: namespace,
 				Name:      "jobs_in_queue",
 				Help:      "Number of remained jobs in queue",
+			},
+			[]string{"queue_name"},
+		),
+		failedQueueStatus: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "jobs_in_failed_queue",
+				Help:      "Number of jobs in failed queue",
 			},
 			[]string{"queue_name"},
 		),
@@ -80,6 +89,7 @@ func newExporter(config *Config) (*exporter, error) {
 func (e *exporter) Describe(ch chan<- *prometheus.Desc) {
 	e.scrapeFailures.Describe(ch)
 	e.queueStatus.Describe(ch)
+	e.failedQueueStatus.Describe(ch)
 	e.processed.Describe(ch)
 	e.failedQueue.Describe(ch)
 	e.failedTotal.Describe(ch)
@@ -141,6 +151,19 @@ func (e *exporter) collect(ch chan<- prometheus.Metric) error {
 		e.queueStatus.WithLabelValues(q).Set(float64(n))
 	}
 
+	failed_queues, err := redis.SMembers(fmt.Sprintf("%s:failed_queues", resqueNamespace)).Result()
+	if err != nil {
+		return err
+	}
+
+	for _, q := range failed_queues {
+		n, err := redis.LLen(fmt.Sprintf("%s:%s", resqueNamespace, q)).Result()
+		if err != nil {
+			return err
+		}
+		e.failedQueueStatus.WithLabelValues(q).Set(float64(n))
+	}
+
 	processed, err := redis.Get(fmt.Sprintf("%s:stat:processed", resqueNamespace)).Result()
 	if err != nil {
 		return err
@@ -186,6 +209,7 @@ func (e *exporter) incrementFailures(ch chan<- prometheus.Metric) {
 
 func (e *exporter) notifyToCollect(ch chan<- prometheus.Metric) {
 	e.queueStatus.Collect(ch)
+	e.failedQueueStatus.Collect(ch)
 	e.processed.Collect(ch)
 	e.failedQueue.Collect(ch)
 	e.failedTotal.Collect(ch)


### PR DESCRIPTION
This is useful when using Resque::Failure::RedisMultiQueue as a backend.

I submitted this same PR to the main project: https://github.com/moznion/resque_exporter